### PR TITLE
Prepare MPV Anime Build v5.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project
 
 - **Project:** MPV Anime Build
-- **Current version:** v5.0
+- **Current version:** v5.1
 - **Repository:** https://github.com/Chinna95P/mpv-anime-build
 
 ## General development rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here.
 
 ---
 
+## [v5.1] – Reliable Eco Persistence & Preferred Subtitle Fallbacks
+
+### 🔋 Power Saving & User Settings
+* **Durable Eco Ownership:** The complete `[Low-End]` profile now remains authoritative while Power Saving is active, including across playlist/file changes and metadata-triggered profile evaluation.
+* **Safe Remembered Settings:** Saved `user-<custom-name>.conf` preferences that overlap with `[Low-End]` no longer silently undo Eco scalers or dithering. Settings outside the Eco profile continue to apply normally.
+* **Deterministic Eco Exit:** Leaving Power Saving restores every option owned by `[Low-End]`, then hands control back to the smart profile and reapplies the user's saved preferences in a defined order.
+* **Stable Power Transitions:** Rapid battery/AC changes cancel stale timers, preserve user-paused playback, and avoid stuck pause or outdated Eco state.
+* **Profile-Driven Ownership:** Eco-owned properties are read from mpv's `[Low-End]` profile with a safe built-in fallback, keeping the persistence layer synchronized with future profile changes.
+
+### 💬 Subtitle Selection
+* **Preferred SDH Fallback:** If the only complete subtitle in a preferred `slang` language is SDH or marked hearing-impaired, it is now chosen before a clean subtitle in an unrelated language.
+* **Clean Track Priority Preserved:** A clean preferred-language subtitle still outranks a preferred-language SDH track.
+* **Incomplete Track Protection:** Forced, signs-only, songs, lyrics, colored, and karaoke tracks remain excluded from the SDH fallback and Anime dialogue shortcuts.
+
+### ✅ Cross-Platform Validation
+* Tested automatic and manual Eco transitions, next-file persistence, rapid power-state changes, settings restoration, and HDR coexistence on real Linux and Windows 11 hardware.
+* Independently tested the subtitle fix against purpose-built MKVs covering clean, SDH, hearing-impaired, forced, signs-only, and unrelated-language combinations.
+
+### 🙏 Community
+* Thanks to **francomeisterm** for identifying the Eco persistence conflict, reviewing the ownership model, and thoroughly validating the Linux behavior.
+* Thanks to **dovahkinGH** for validating the Windows power/HDR paths on real laptop hardware and independently testing the complete preferred-subtitle matrix.
+
+---
+
 ## [v5.0] – Cross-Platform HDR, Durable User Overrides & Community Fixes
 
 ### ✨ New Features & Enhancements

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
-# 🎬 MPV Anime Build v5.0
-> **The Cross-Platform HDR & Remembered Settings Update: reliable Windows/Linux HDR handling, durable user overrides, community-reported fixes, and clearer Anime shader naming.**
+# 🎬 MPV Anime Build v5.1
+> **The Eco Persistence & Preferred Subtitle Update: reliable Power Saving across file changes and smarter preferred-language SDH selection.**
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/Pvf3huxFvU)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Chinna95P/mpv-anime-build)
@@ -19,7 +19,10 @@ The MPV Anime Build is also available for **Android (mpvEX / Aniyomi)**!
 
 ---
 
-## 🚀 What's New in (v4.0 - v5.0)
+## 🚀 What's New in (v4.0 - v5.1)
+
+* **🔋 Durable Eco Profile Ownership (v5.1):** Power Saving now remains authoritative across file loads, metadata changes, and saved UOSC setting updates. User preferences are preserved for normal playback and restored deterministically when Eco mode ends.
+* **💬 Preferred-Language SDH Fallback (v5.1):** When no clean preferred-language subtitle exists, the selector now chooses a preferred-language SDH or hearing-impaired track before an unrelated clean language, while still rejecting forced and signs-only tracks.
 
 * **🌈 Cross-Platform HDR Detection (v5.0):** Windows uses the DisplayConfig API with a WMI compatibility fallback, KDE Plasma uses KScreen, and other Linux compositors defer safely to mpv's native colorspace negotiation. Windows and Linux detection paths remain strictly isolated.
 * **💾 Durable User Overrides (v5.0):** UOSC Controls and HDR choices are remembered in untracked `user-<custom-name>.conf` files, loaded alphabetically and reapplied after profile evaluation so build updates do not overwrite personal settings.

--- a/docs/Cheatsheet.md
+++ b/docs/Cheatsheet.md
@@ -1,4 +1,4 @@
-# ⚡ MPV Anime Build v5.0 – Cheat Sheet
+# ⚡ MPV Anime Build v5.1 – Cheat Sheet
 
 A complete reference for all keyboard shortcuts and commands defined in your `input.conf`.
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>MPV Anime Build v5.0 | 4K ArtCNN, Anime4K, NNEDI3 & FSRCNNX Automated Resolution Adaptive Upscaling (using Auto-Detection for Anime/Live-Action)</title>
+    <title>MPV Anime Build v5.1 | 4K ArtCNN, Anime4K, NNEDI3 & FSRCNNX Automated Resolution Adaptive Upscaling (using Auto-Detection for Anime/Live-Action)</title>
 
     <meta name="description" content="Automated MPV configuration for Real-time Anime and Live-Action Upscaling.">
 
@@ -12,12 +12,12 @@
 
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://chinna95p.github.io/mpv-anime-build/">
-    <meta property="og:title" content="MPV Anime Build v5.0">
+    <meta property="og:title" content="MPV Anime Build v5.1">
     <meta property="og:description" content="Automated MPV configuration for real-time Anime and Live-Action upscaling. Features new Glass UI (UOSC), True HDR Passthrough, and centralized Anime controls.">
     <meta property="og:image" content="https://chinna95p.github.io/mpv-anime-build/screenshots/anime-on.jpg">
 
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:title" content="MPV Anime Build v5.0">
+    <meta property="twitter:title" content="MPV Anime Build v5.1">
     <meta property="twitter:description" content="Automated MPV configuration for real-time Anime and Live-Action upscaling. Features new Glass UI (UOSC), True HDR Passthrough, and centralized Anime controls.">
     <meta property="twitter:image" content="https://chinna95p.github.io/mpv-anime-build/screenshots/anime-on.jpg">
 
@@ -306,7 +306,7 @@
         "name": "Chinna95P"
       },
       "downloadUrl": "https://github.com/Chinna95P/mpv-anime-build/releases",
-      "softwareVersion": "v5.0"
+      "softwareVersion": "v5.1"
     }
     </script>
 </head>
@@ -314,13 +314,13 @@
 
     <header>
         <div class="container hero-content">
-            <h1>MPV Anime Build v5.0</h1>
+            <h1>MPV Anime Build v5.1</h1>
             <p>Performance. Audio Profiling. Pure Immersive Media.</p>
 
             <div class="hero-actions">
                 <div class="primary-buttons">
                     <a href="https://github.com/Chinna95P/mpv-anime-build/releases" class="btn btn-download">
-                        📥 Download v5.0 Release
+                        📥 Download v5.1 Release
                     </a>
                     <a href="https://github.com/Chinna95P/mpv-anime-build/tree/android" class="btn btn-android">
                         📱 Android Build
@@ -756,9 +756,21 @@ image_types=</code></pre>
 	<section class="features" style="padding-bottom: 0;">
         <div class="container">
 
-            <h2 class="slider-title reveal">What's New (v3.0 - v5.0)</h2>
+            <h2 class="slider-title reveal">What's New (v3.0 - v5.1)</h2>
 
             <div class="grid">
+
+                <div class="card reveal" style="border-top: 3px solid #d29922;">
+                    <span class="icon">🔋</span>
+                    <h3>Reliable Eco Persistence</h3>
+                    <p>The complete Low-End profile stays active across file and metadata changes, while remembered preferences return safely when Power Saving ends.</p>
+                </div>
+
+                <div class="card reveal" style="border-top: 3px solid #58a6ff;">
+                    <span class="icon">💬</span>
+                    <h3>Smarter Preferred Subtitles</h3>
+                    <p>Preferred-language SDH tracks now win over unrelated clean languages when needed, without changing clean, forced, or signs-only priorities.</p>
+                </div>
 
                 <div class="card reveal" style="border-top: 3px solid #58a6ff;">
                     <span class="icon">🌈</span>
@@ -1072,7 +1084,7 @@ image_types=</code></pre>
 
 
     <footer>
-        <p>MPV Anime Build v5.0 • Maintained by Chinna95P</p>
+        <p>MPV Anime Build v5.1 • Maintained by Chinna95P</p>
         <p>Credits: bloc97 (Anime4K), Th-Underscore (Anime4K-Ultra), igv (FSRCNNX), bjin (KrigBilateral), tomasklaen (UOSC), po5 (Thumbfast), cvzi (mpv-youtube-download), @WaruiDevil (Up Next)</p>
     </footer>
 

--- a/script-opts/build_info.conf
+++ b/script-opts/build_info.conf
@@ -1,1 +1,1 @@
-version=v5.0
+version=v5.1


### PR DESCRIPTION
## Summary

- bump the authoritative build version to v5.1
- document reliable Eco profile ownership and restoration across file and power-state changes
- document preferred-language SDH fallback behavior and preserved exclusion priorities
- synchronize README, changelog, cheat sheet, website metadata, and contributor instructions
- credit @francomeisterm and @dovahkinGH for the reports, analysis, and cross-platform testing

## Included fixes

- #32 fixes Eco/user-setting persistence conflicts reported in #31
- #33 fixes preferred-language subtitle fallback when only SDH is available

## Validation

- all affected Lua scripts compile with LuaJIT
- website HTML parses successfully
- active version sources consistently report v5.1
- `git diff --check` passes
- functional changes were validated on real Linux and Windows 11 hardware and with purpose-built subtitle test media