### PR TITLE
Prepare MPV Anime Build v5.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project
 
 - **Project:** MPV Anime Build
-- **Current version:** v5.1
+- **Current version:** v5.2
 - **Repository:** https://github.com/Chinna95P/mpv-anime-build
 
 ## General development rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented here.
 
 ---
 
+## [v5.2] – Live-Action Detection & Safer Playback Defaults
+
+### 🎬 Profile Detection
+* **Restored Live-Action Override:** Reconnected `is_live_action(path, title)` to the main profile evaluation flow so explicit Live-Action signals take priority over Anime folder, Japanese-audio, release-syntax, and CRC signals in Auto mode.
+* **Path and Title Coverage:** `Live Action`, `Live-Action`, `liveaction`, `drama`, and `real person` continue to be recognized in either the media path or title.
+* **Anime Mode Semantics Preserved:** Forced Anime Mode still selects Anime processing, while Auto mode now correctly routes explicitly marked Live-Action content to its resolution-appropriate profile.
+
+### 🖼️ Thumbnail Playback
+* **Software-Decoded Thumbfast:** Changed the shipped Thumbfast option from `hwdec=yes` to `hwdec=no`, matching the script's safe default and preventing the thumbnail helper from depending on hardware-decoder support.
+
+### 🌐 Stream Subtitles
+* **English-Only yt-dlp Requests:** Removed the accidental Telugu `te` and `tel` entries from `ytdl-raw-options-append`; authored and automatic stream subtitles now request only `en` and `en-orig`.
+
+### 🎨 Documentation
+* **Correct Smart Skip Colors:** Corrected the Smart Skip screenshot descriptions and chapter-timeline documentation to identify OP as green, ED as blue, PV as magenta, and Intro as orange.
+
+### ✅ Validation
+* Verified the explicit Live-Action override with the 1920×1080 `Ranma ½ Live-Action.mkv` test case inside an Anime folder with Japanese audio; Auto mode selected the Live-Action context and `FHD-Native` profile.
+* Loaded the affected controller and Thumbfast scripts through mpv's embedded Lua runtime without script errors, and validated the updated yt-dlp option syntax with mpv.
+
+---
+
 ## [v5.1] – Reliable Eco Persistence & Preferred Subtitle Fallbacks
 
 ### 🔋 Power Saving & User Settings

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
-# 🎬 MPV Anime Build v5.1
-> **The Eco Persistence & Preferred Subtitle Update: reliable Power Saving across file changes and smarter preferred-language SDH selection.**
+# 🎬 MPV Anime Build v5.2
+> **The Detection & Playback Defaults Update: reliable Live-Action overrides, safer thumbnail decoding, and focused English stream subtitles.**
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/Pvf3huxFvU)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Chinna95P/mpv-anime-build)
@@ -21,7 +21,12 @@ The MPV Anime Build is also available for **Android (mpvEX / Aniyomi)**!
 
 ---
 
-## 🚀 What's New in (v4.0 - v5.1)
+## 🚀 What's New in (v4.0 - v5.2)
+
+* **🎬 Restored Live-Action Path Override (v5.2):** Explicit `Live Action`, `Live-Action`, `liveaction`, `drama`, and `real person` path/title signals once again take priority over Anime folder and Japanese-audio signals while Anime Mode is set to Auto.
+* **🖼️ Safer Thumbfast Decoding (v5.2):** Thumbnail generation now explicitly uses software decoding by default, matching Thumbfast's built-in safe fallback and avoiding hardware-decoder instability in the helper process.
+* **🌐 English-Only Stream Subtitles (v5.2):** yt-dlp automatic and authored subtitle requests are limited to English and original-English tracks; unintended Telugu language requests were removed.
+* **🎨 Correct Smart Skip Documentation (v5.2):** Website image descriptions and chapter-timeline documentation now match the displayed colors: OP green, ED blue, PV magenta, and Intro orange.
 
 * **🔋 Durable Eco Profile Ownership (v5.1):** Power Saving now remains authoritative across file loads, metadata changes, and saved UOSC setting updates. User preferences are preserved for normal playback and restored deterministically when Eco mode ends.
 * **💬 Preferred-Language SDH Fallback (v5.1):** When no clean preferred-language subtitle exists, the selector now chooses a preferred-language SDH or hearing-impaired track before an unrelated clean language, while still rejecting forced and signs-only tracks.

--- a/docs/Cheatsheet.md
+++ b/docs/Cheatsheet.md
@@ -1,4 +1,4 @@
-# ⚡ MPV Anime Build v5.1 – Cheat Sheet
+# ⚡ MPV Anime Build v5.2 – Cheat Sheet
 
 A complete reference for all keyboard shortcuts and commands defined in your `input.conf`.
 

--- a/index.html
+++ b/index.html
@@ -708,11 +708,11 @@ image_types=</code></pre>
                     </div>
                     <div style="background: #161b22; padding: 10px; border-radius: 8px; border: 1px solid #30363d;">
                         <img src="screenshots/ui9.jpg" alt="Blue ED Skip" style="width: 100%; border-radius: 4px; display: block;">
-                        <p style="text-align: center; color: #8b949e; margin-top: 10px; font-size: 0.9rem;"><strong>Ending (ED)</strong> • Orange Indicator</p>
+                        <p style="text-align: center; color: #8b949e; margin-top: 10px; font-size: 0.9rem;"><strong>Ending (ED)</strong> • Blue Indicator</p>
                     </div>
                     <div style="background: #161b22; padding: 10px; border-radius: 8px; border: 1px solid #30363d;">
-                        <img src="screenshots/ui8.jpg" alt="Blue Intro Skip" style="width: 100%; border-radius: 4px; display: block;">
-                        <p style="text-align: center; color: #8b949e; margin-top: 10px; font-size: 0.9rem;"><strong>Generic Intro</strong> • Blue Theme</p>
+                        <img src="screenshots/ui8.jpg" alt="Orange Intro Skip" style="width: 100%; border-radius: 4px; display: block;">
+                        <p style="text-align: center; color: #8b949e; margin-top: 10px; font-size: 0.9rem;"><strong>Generic Intro</strong> • Orange Theme</p>
                     </div>
                     <div style="background: #161b22; padding: 10px; border-radius: 8px; border: 1px solid #30363d;">
                         <img src="screenshots/ui10.jpg" alt="Skipped Feedback" style="width: 100%; border-radius: 4px; display: block;">
@@ -837,7 +837,7 @@ image_types=</code></pre>
                 <div class="card reveal" style="border-top: 3px solid #00FF00;">
                     <span class="icon">🌈</span>
                     <h3>Color-Coded Chapter Timeline</h3>
-                    <p>UOSC 5.13.0 now highlights detected OP, ED, PV, and Intro chapters with the same transparent colors used by Skip Intro: <strong>OP green</strong>, <strong>ED orange</strong>, <strong>PV magenta</strong>, and <strong>Intro blue</strong>.</p>
+                    <p>UOSC 5.13.0 now highlights detected OP, ED, PV, and Intro chapters with the same transparent colors used by Skip Intro: <strong>OP green</strong>, <strong>ED blue</strong>, <strong>PV magenta</strong>, and <strong>Intro orange</strong>.</p>
                 </div>
 
                 <div class="card reveal" style="border-top: 3px solid #2ea043;">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>MPV Anime Build v5.1 | 4K ArtCNN, Anime4K, NNEDI3 & FSRCNNX Automated Resolution Adaptive Upscaling (using Auto-Detection for Anime/Live-Action)</title>
+    <title>MPV Anime Build v5.2 | 4K ArtCNN, Anime4K, NNEDI3 & FSRCNNX Automated Resolution Adaptive Upscaling (using Auto-Detection for Anime/Live-Action)</title>
 
     <meta name="description" content="Automated MPV configuration for Real-time Anime and Live-Action Upscaling.">
 
@@ -12,12 +12,12 @@
 
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://chinna95p.github.io/mpv-anime-build/">
-    <meta property="og:title" content="MPV Anime Build v5.1">
+    <meta property="og:title" content="MPV Anime Build v5.2">
     <meta property="og:description" content="Automated MPV configuration for real-time Anime and Live-Action upscaling. Features new Glass UI (UOSC), True HDR Passthrough, and centralized Anime controls.">
     <meta property="og:image" content="https://chinna95p.github.io/mpv-anime-build/screenshots/anime-on.jpg">
 
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:title" content="MPV Anime Build v5.1">
+    <meta property="twitter:title" content="MPV Anime Build v5.2">
     <meta property="twitter:description" content="Automated MPV configuration for real-time Anime and Live-Action upscaling. Features new Glass UI (UOSC), True HDR Passthrough, and centralized Anime controls.">
     <meta property="twitter:image" content="https://chinna95p.github.io/mpv-anime-build/screenshots/anime-on.jpg">
 
@@ -309,7 +309,7 @@
         "name": "Chinna95P"
       },
       "downloadUrl": "https://github.com/Chinna95P/mpv-anime-build/releases",
-      "softwareVersion": "v5.1"
+      "softwareVersion": "v5.2"
     }
     </script>
 </head>
@@ -317,13 +317,13 @@
 
     <header>
         <div class="container hero-content">
-            <h1>MPV Anime Build v5.1</h1>
+            <h1>MPV Anime Build v5.2</h1>
             <p>Performance. Audio Profiling. Pure Immersive Media.</p>
 
             <div class="hero-actions">
                 <div class="primary-buttons">
                     <a href="https://github.com/Chinna95P/mpv-anime-build/releases" class="btn btn-download">
-                        📥 Download v5.1 Release
+                        📥 Download v5.2 Release
                     </a>
                     <a href="https://github.com/Chinna95P/mpv-anime-build/tree/android" class="btn btn-android">
                         📱 Android Build
@@ -763,9 +763,27 @@ image_types=</code></pre>
 	<section class="features" style="padding-bottom: 0;">
         <div class="container">
 
-            <h2 class="slider-title reveal">What's New (v3.0 - v5.1)</h2>
+            <h2 class="slider-title reveal">What's New (v3.0 - v5.2)</h2>
 
             <div class="grid">
+
+                <div class="card reveal" style="border-top: 3px solid #ff7b72;">
+                    <span class="icon">🎬</span>
+                    <h3>Reliable Live-Action Overrides</h3>
+                    <p>Explicit Live-Action path and title markers once again override Anime folder and Japanese-audio signals in Auto mode, selecting the correct resolution-aware profile.</p>
+                </div>
+
+                <div class="card reveal" style="border-top: 3px solid #58a6ff;">
+                    <span class="icon">🖼️</span>
+                    <h3>Safer Thumbnail Decoding</h3>
+                    <p>Thumbfast now ships with software decoding enabled for its helper process, avoiding hardware-decoder compatibility problems during thumbnail generation.</p>
+                </div>
+
+                <div class="card reveal" style="border-top: 3px solid #2ea043;">
+                    <span class="icon">🌐</span>
+                    <h3>Focused Stream Subtitles</h3>
+                    <p>yt-dlp subtitle requests now stay limited to English and original-English tracks, removing unintended Telugu language requests.</p>
+                </div>
 
                 <div class="card reveal" style="border-top: 3px solid #d29922;">
                     <span class="icon">🔋</span>
@@ -1091,7 +1109,7 @@ image_types=</code></pre>
 
 
     <footer>
-        <p>MPV Anime Build v5.1 • Maintained by Chinna95P</p>
+        <p>MPV Anime Build v5.2 • Maintained by Chinna95P</p>
         <p>Credits: bloc97 (Anime4K), Th-Underscore (Anime4K-Ultra), igv (FSRCNNX), bjin (KrigBilateral), tomasklaen (UOSC), po5 (Thumbfast), cvzi (mpv-youtube-download), @WaruiDevil (Up Next)</p>
     </footer>
 

--- a/mpv.conf
+++ b/mpv.conf
@@ -130,7 +130,7 @@ stretch-image-subs-to-screen=yes
 ytdl-format=bestvideo[height<=?2160][fps<=?60]+bestaudio/best
 #ytdl-raw-options=format="bestvideo+bestaudio/best",audio-quality=0
 ytdl-raw-options=extractor-args="youtube:player_client=default,-android_sdkless"
-ytdl-raw-options-append=sub-lang=en,en-orig,te,tel,write-subs=,write-auto-subs=
+ytdl-raw-options-append=sub-lang=en,en-orig,write-subs=,write-auto-subs=
 
 #############
 # Languages #

--- a/script-opts/build_info.conf
+++ b/script-opts/build_info.conf
@@ -1,1 +1,1 @@
-version=v5.1
+version=v5.2

--- a/script-opts/thumbfast.conf
+++ b/script-opts/thumbfast.conf
@@ -24,7 +24,7 @@ network=yes
 audio=no
 
 # Hardware decoding (Keep off for safety)
-hwdec=yes
+hwdec=no
 
 # Direct IO (Keep off for Windows)
 direct_io=no

--- a/scripts/anime_profile_controller.lua
+++ b/scripts/anime_profile_controller.lua
@@ -747,6 +747,9 @@ local function evaluate()
     local signal_folder = is_anime_folder(path)
     local signal_shiru  = (shiru_opt == "anime")
 
+    -- B. Explicit Live Action Override (checks both path and title)
+    local signal_live_action = is_live_action(path, title)
+
     -- [v4.6] Strict Syntax Check: MUST have [Prefix] AND ([Suffix] OR " - 01" episode dash)
     local signal_syntax = false
     if filename:match("^%[.-%]") then


### PR DESCRIPTION
## Summary

- restore the explicit Live-Action path/title override in the Anime profile controller
- switch the shipped Thumbfast helper configuration to software decoding
- limit yt-dlp subtitle requests to English and original-English tracks
- correct Smart Skip and chapter-timeline color descriptions
- bump the authoritative build version and synchronize README, changelog, cheat sheet, website metadata, and contributor instructions for v5.2

## Validation

- verified the exact 1920×1080 `Ranma ½ Live-Action.mkv` case inside an Anime folder with Japanese audio selects the Live-Action context and `FHD-Native` profile in Auto mode
- loaded the affected controller and Thumbfast scripts through mpv’s embedded Lua runtime without script errors
- validated the updated yt-dlp option syntax with mpv
- parsed the updated website HTML and confirmed active version markers report v5.2
- built and integrity-tested the install-ready v5.2 ZIP using the same 315-entry flat layout as v5.1
- `git diff --check` passes